### PR TITLE
Juniper upgrade - Fix resource decode

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -83,7 +83,7 @@ class PDFXBlock(XBlock):
 
         resource_content = pkg_resources.resource_string(__name__,
                                                          resource_path)
-        return str(resource_content)
+        return resource_content.decode('utf-8')
 
     def render_template(self, path, context=None):
         """


### PR DESCRIPTION
Needed to do `resource.decode('utf-8')` instead of `str(resource)`

https://appsembler.atlassian.net/browse/RED-1951